### PR TITLE
feat: per-user token auth from frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # GitHub Personal Access Token with Copilot access
-# Leave empty to use gh CLI auth (recommended: run "gh auth login" first)
-GITHUB_TOKEN=
+# Optional: used as server-side fallback for testing/CI
+# Users provide their own token via the web UI
+COPILOT_GITHUB_TOKEN=
 
 # Server port (optional, defaults to 3000)
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 A minimal web application that provides a chat interface to **GitHub Copilot**, using the official [`@github/copilot-sdk`](https://github.com/github/copilot-sdk). Every message uses the same Copilot engine as github.com and counts toward your premium request quota.
 
+**Multi-user support:** Each user provides their own GitHub token via the web UI. Tokens are stored in the browser's localStorage and sent to the server per-request — the server never stores tokens globally.
+
 ## Architecture
 
 ```
 ┌─────────────┐     HTTP/SSE      ┌──────────────────┐    JSON-RPC     ┌─────────────┐        ┌─────────────────┐
 │   Browser    │  ◄──────────►    │  Express Server   │  ◄──────────►  │ Copilot CLI  │  ◄──►  │ GitHub Copilot  │
-│  (HTML/JS)   │   /api/chat      │  (server.ts)      │   via SDK      │ (server mode)│        │ Backend (cloud) │
+│  (HTML/JS)   │   /api/chat      │  (server.ts)      │   via SDK      │ (per-token)  │        │ Backend (cloud) │
+│  Token in    │  Authorization:  │  Per-user clients  │                │              │        │                 │
+│  localStorage│  Bearer <token>  │  in Map<token,     │                │              │        │                 │
+│              │                  │  CopilotClient>   │                │              │        │                 │
 └─────────────┘                   └──────────────────┘                 └─────────────┘        └─────────────────┘
 ```
 
@@ -15,34 +20,35 @@ A minimal web application that provides a chat interface to **GitHub Copilot**, 
 
 | Component | File(s) | Role |
 |-----------|---------|------|
-| **Frontend** | `public/index.html`, `public/app.js` | GitHub dark-themed chat UI. Sends messages via fetch, reads streaming responses via SSE, renders tokens incrementally. |
-| **Express Server** | `server.ts` | Hosts static files, manages Copilot sessions, proxies chat through SDK, streams responses as Server-Sent Events. |
+| **Frontend** | `public/index.html`, `public/app.js` | GitHub dark-themed chat UI. Users enter their token in the header, which is saved to localStorage and sent as `Authorization: Bearer <token>` on every API request. |
+| **Express Server** | `server.ts` | Hosts static files, creates a separate `CopilotClient` per user token, manages sessions keyed by `token:sessionId`, streams responses as SSE. |
 | **Copilot SDK** | `@github/copilot-sdk` | Official TypeScript SDK. Communicates with the Copilot CLI process over JSON-RPC. |
-| **Copilot CLI** | System binary | Headless server mode. Managed automatically by the SDK — spawned on first use, stopped on shutdown. |
+| **Copilot CLI** | System binary | Headless server mode. Managed automatically by the SDK — one instance per user token. |
 
 ### Data Flow
 
-1. User types a message in the browser
-2. Frontend sends `POST /api/chat` with `{ message, sessionId, model }`
-3. Server creates or retrieves a `CopilotSession` from the in-memory session map
-4. SDK fires `assistant.message_delta` events → server writes SSE `delta` events
-5. SDK fires `session.idle` → server writes SSE `done` event with session ID
-6. Frontend parses SSE stream, appends tokens to the chat bubble in real time
+1. User enters their GitHub token in the web UI header and clicks "Save Token"
+2. Token is stored in `localStorage` — never sent to the server except as an auth header
+3. User types a message; frontend sends `POST /api/chat` with `Authorization: Bearer <token>` header
+4. Server extracts the token, gets or creates a `CopilotClient` for that token
+5. Server creates or retrieves a `CopilotSession` from the session map (keyed by `token:sessionId`)
+6. SDK fires `assistant.message_delta` events → server writes SSE `delta` events
+7. SDK fires `session.idle` → server writes SSE `done` event with session ID
+8. Frontend parses SSE stream, appends tokens to the chat bubble in real time
 
 ### Session Management
 
-- Sessions stored in a `Map<string, CopilotSession>` in server memory
+- Clients stored in a `Map<string, CopilotClient>` — one per unique user token
+- Sessions stored in a `Map<string, CopilotSession>` — keyed by `token:sessionId`
 - Each session maintains full conversation history (managed by SDK/CLI)
 - New chat = new session; follow-up messages reuse the same session ID
-- Sessions cleaned up on server shutdown via `client.stop()`
+- All clients cleaned up on server shutdown
 
 ## Prerequisites
 
 - **Node.js 18+** — `node --version`
 - **GitHub Copilot subscription** (Free, Pro, or Pro+)
-- **Authentication** — one of:
-  - `gh` CLI logged in (`gh auth login`) — **recommended**
-  - GitHub fine-grained PAT with Copilot scope in `.env`
+- **GitHub token** — each user needs their own fine-grained PAT with Copilot scope
 
 ## Setup
 
@@ -50,43 +56,49 @@ A minimal web application that provides a chat interface to **GitHub Copilot**, 
 # Install dependencies
 npm install
 
-# Configure (optional — skip if using gh CLI auth)
+# (Optional) Set a fallback token for testing/CI
 cp .env.example .env
-# Edit .env and add GITHUB_TOKEN if not using gh CLI
+# Edit .env and add COPILOT_GITHUB_TOKEN
 
 # Start the server
 npm start
 
-# Open http://localhost:3000
+# Open http://localhost:3000 and enter your token in the header
 ```
 
 ### Environment Variables
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `GITHUB_TOKEN` | No | — | GitHub fine-grained PAT with Copilot scope. If empty, falls back to `gh` CLI auth. |
+| `COPILOT_GITHUB_TOKEN` | No | — | Server-side fallback token for testing/CI. In normal use, each user provides their own token via the web UI. |
 | `PORT` | No | `3000` | Server port |
 
 ### Authentication
 
-The app supports two authentication methods:
+Each user provides their own GitHub token through the web UI:
 
-1. **`gh` CLI auth (recommended)** — Run `gh auth login` once. The SDK detects stored credentials automatically. No token needed in `.env`.
-2. **Fine-grained PAT** — Create a token at https://github.com/settings/tokens with the `copilot` scope. Set it as `GITHUB_TOKEN` in `.env`. Classic PATs (`ghp_`) may not have the required scope — use fine-grained tokens (`github_pat_`).
+1. Create a **fine-grained PAT** at https://github.com/settings/tokens with the `copilot` scope
+2. Open the app in your browser
+3. Paste the token in the input field and click **Save Token**
+4. The token is stored in your browser's `localStorage` and sent as `Authorization: Bearer <token>` on each API request
+
+> **Note:** Classic PATs (`ghp_`) may not have the required Copilot scope — use fine-grained tokens (`github_pat_`).
+
+The server also accepts `COPILOT_GITHUB_TOKEN` in `.env` as a fallback (used when no `Authorization` header is present). This is useful for automated testing and CI.
 
 ## API Endpoints
 
 ### `GET /api/health`
 
-Returns server status, CLI availability, and auth state.
+Returns server status and CLI availability. No auth required.
 
 ```json
-{ "status": "ok", "copilotCli": true, "authenticated": true }
+{ "status": "ok", "copilotCli": true }
 ```
 
 ### `GET /api/models`
 
-Returns available models fetched from `client.listModels()`.
+Returns available models. Requires `Authorization: Bearer <token>` header.
 
 ```json
 { "models": [{ "id": "gpt-4.1", ... }, ...] }
@@ -94,7 +106,7 @@ Returns available models fetched from `client.listModels()`.
 
 ### `POST /api/chat`
 
-Send a message and receive a streaming SSE response.
+Send a message and receive a streaming SSE response. Requires `Authorization: Bearer <token>` header.
 
 **Request:**
 ```json
@@ -127,7 +139,7 @@ The suite has two layers:
 These tests create a `CopilotClient` directly and talk to Copilot:
 
 | Test | What it verifies |
-|------|-----------------|
+|------|------------------|
 | **SDK connect & ping** | Client connects to Copilot CLI subprocess, gets a timestamped ping response |
 | **SDK list models** | `listModels()` returns a non-empty array containing GPT models |
 | **SDK chat (single turn)** | Creates a session, sends a prompt, verifies streaming `assistant.message_delta` events arrive and contain the expected response |
@@ -138,10 +150,10 @@ These tests create a `CopilotClient` directly and talk to Copilot:
 These tests spawn the Express server on port 3099 and hit the HTTP API:
 
 | Test | What it verifies |
-|------|-----------------|
-| **Server health check** | `GET /api/health` returns `{ status: "ok", authenticated: true }` |
-| **Server models endpoint** | `GET /api/models` returns a non-empty model list from the Copilot API |
-| **Server chat (SSE streaming)** | `POST /api/chat` → parses SSE stream → verifies delta events, done event with session ID, and correct response content |
+|------|------------------|
+| **Server health check** | `GET /api/health` returns `{ status: "ok" }` |
+| **Server models endpoint** | `GET /api/models` with auth header returns a non-empty model list |
+| **Server chat (SSE streaming)** | `POST /api/chat` with auth header → parses SSE stream → verifies delta events, done event with session ID, and correct response content |
 
 ### Test Output
 
@@ -180,7 +192,7 @@ These tests spawn the Express server on port 3099 and hit the HTTP API:
 |----------|---------|-------------|
 | `TEST_PORT` | `3099` | Port for the test server (avoids conflict with dev server on 3000) |
 
-Tests use the same auth method as the app: `GITHUB_TOKEN` from `.env` if set, otherwise `gh` CLI credentials.
+Tests use the same auth method: `COPILOT_GITHUB_TOKEN` from `.env` if set, otherwise `gh` CLI credentials. Server API tests send the token via `Authorization` header.
 
 ## File Structure
 
@@ -217,8 +229,8 @@ Models are fetched dynamically from the Copilot API. Pricing depends on your pla
 
 | Issue | Fix |
 |-------|-----|
-| `Failed to list models: 400` | Token lacks Copilot scope. Use a fine-grained PAT (`github_pat_`) with Copilot permission, or switch to `gh` CLI auth. |
-| `Not authenticated` | Set `GITHUB_TOKEN` in `.env` or run `gh auth login`. |
+| `Failed to list models: 400` | Token lacks Copilot scope. Use a fine-grained PAT (`github_pat_`) with Copilot permission. |
+| `401 Missing token` | Enter your GitHub token in the web UI header and click "Save Token", or set `COPILOT_GITHUB_TOKEN` in `.env`. |
 | `EADDRINUSE` | Kill leftover node processes: `Stop-Process -Name node -Force` (Windows) or `pkill node` (macOS/Linux). |
-| Server starts but chat fails | Check `GET /api/health` — verify `authenticated: true` and `copilotCli: true`. |
+| Server starts but chat fails | Check `GET /api/health` — verify `copilotCli: true`. Ensure your token is valid. |
 | Streaming stops mid-response | Network or token issue. Refresh the page and try again. |

--- a/public/app.js
+++ b/public/app.js
@@ -11,10 +11,63 @@ const newChatBtn = document.getElementById("new-chat-btn");
 const modelSelect = document.getElementById("model-select");
 const statusDot = document.getElementById("status-dot");
 const statusText = document.getElementById("status-text");
+const tokenInput = document.getElementById("token-input");
+const saveTokenBtn = document.getElementById("save-token-btn");
+
+// --- Token Management ---
+function getToken() {
+  return localStorage.getItem("copilot_github_token") || "";
+}
+
+function saveToken(token) {
+  if (token) {
+    localStorage.setItem("copilot_github_token", token);
+  } else {
+    localStorage.removeItem("copilot_github_token");
+  }
+  updateTokenUI();
+}
+
+function updateTokenUI() {
+  const token = getToken();
+  if (token) {
+    tokenInput.value = "";
+    tokenInput.placeholder = "Token saved ✓  (click Save to clear)";
+    saveTokenBtn.textContent = "Clear Token";
+  } else {
+    tokenInput.placeholder = "GitHub token (ghp_... or github_pat_...)";
+    saveTokenBtn.textContent = "Save Token";
+  }
+}
+
+function authHeaders() {
+  const token = getToken();
+  const headers = {};
+  if (token) {
+    headers["Authorization"] = "Bearer " + token;
+  }
+  return headers;
+}
 
 // --- Init ---
+updateTokenUI();
 checkHealth();
-loadModels();
+if (getToken()) loadModels();
+
+saveTokenBtn.addEventListener("click", () => {
+  const current = getToken();
+  if (current) {
+    // Clear token
+    saveToken("");
+    modelSelect.innerHTML = '<option value="gpt-4.1">Enter token to load models</option>';
+  } else {
+    // Save new token
+    const val = tokenInput.value.trim();
+    if (!val) return;
+    saveToken(val);
+    loadModels();
+  }
+});
 
 inputEl.addEventListener("keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) {
@@ -47,7 +100,7 @@ async function checkHealth() {
       statusDot.classList.remove("disconnected");
       const parts = [];
       if (data.copilotCli) parts.push("CLI ready");
-      if (data.authenticated) parts.push("Authenticated");
+      if (getToken()) parts.push("Token set");
       statusText.textContent = parts.length ? parts.join(" · ") : "Connected";
     } else {
       setDisconnected("Server error");
@@ -65,7 +118,11 @@ function setDisconnected(msg) {
 // --- Load Models ---
 async function loadModels() {
   try {
-    const res = await fetch("/api/models");
+    const res = await fetch("/api/models", { headers: authHeaders() });
+    if (res.status === 401) {
+      modelSelect.innerHTML = '<option value="gpt-4.1">Enter token to load models</option>';
+      return;
+    }
     const data = await res.json();
     if (data.models && Array.isArray(data.models)) {
       modelSelect.innerHTML = "";
@@ -83,7 +140,7 @@ async function loadModels() {
       }
     }
   } catch {
-    modelSelect.innerHTML = '<option value="gpt-4.1">gpt-4.1</option>';
+    modelSelect.innerHTML = '<option value="gpt-4.1">Enter token to load models</option>';
   }
 }
 
@@ -116,7 +173,7 @@ async function sendMessage() {
 
     const response = await fetch("/api/chat", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders() },
       body,
     });
 

--- a/public/index.html
+++ b/public/index.html
@@ -247,6 +247,10 @@
       Copilot Chat
     </div>
     <div class="controls">
+      <input type="password" id="token-input" placeholder="GitHub token (ghp_... or github_pat_...)" spellcheck="false" autocomplete="off"
+        style="width: 260px; background: var(--color-bg-tertiary); color: var(--color-text); border: 1px solid var(--color-border);
+        border-radius: var(--radius); padding: 5px 8px; font-family: var(--font-sans); font-size: 13px; outline: none;" />
+      <button class="btn" id="save-token-btn" title="Save token to browser">Save Token</button>
       <select id="model-select" title="Select model">
         <option value="gpt-4.1">Loading models...</option>
       </select>

--- a/server.ts
+++ b/server.ts
@@ -15,23 +15,34 @@ app.use(express.static(path.join(__dirname, "public")));
 
 const PORT = parseInt(process.env.PORT || "3000", 10);
 
-// --- Copilot Client ---
+// --- Per-user Copilot Clients ---
 
-let client: CopilotClient | null = null;
+// Key: github token → CopilotClient (one client per user token)
+const clients = new Map<string, CopilotClient>();
+// Key: "token:sessionId" → CopilotSession
 const sessions = new Map<string, CopilotSession>();
 
-function buildClientOptions() {
-  const token = process.env.GITHUB_TOKEN;
-  if (token) return { githubToken: token };
-  return { useLoggedInUser: true };
+function extractToken(req: Request): string | undefined {
+  const authHeader = req.headers.authorization;
+  if (authHeader?.startsWith("Bearer ")) {
+    return authHeader.slice(7);
+  }
+  // Fallback to env var for testing/CI
+  return process.env.COPILOT_GITHUB_TOKEN || undefined;
 }
 
-async function getClient(): Promise<CopilotClient> {
-  if (!client) {
-    client = new CopilotClient(buildClientOptions());
-    await client.start();
+async function getClientForToken(token: string): Promise<CopilotClient> {
+  if (clients.has(token)) {
+    return clients.get(token)!;
   }
+  const client = new CopilotClient({ githubToken: token });
+  await client.start();
+  clients.set(token, client);
   return client;
+}
+
+function sessionKey(token: string, sessionId: string): string {
+  return `${token}:${sessionId}`;
 }
 
 // --- Helpers ---
@@ -45,36 +56,29 @@ function isCopilotCliAvailable(): boolean {
   }
 }
 
-function isAuthenticated(): boolean {
-  // True if PAT is set or gh CLI is available
-  if (process.env.GITHUB_TOKEN) return true;
-  try {
-    execSync("gh auth status", { stdio: "ignore" });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function generateSessionId(): string {
   return crypto.randomUUID();
 }
 
 // --- Routes ---
 
-// Health check
+// Health check (no auth required)
 app.get("/api/health", (_req: Request, res: Response) => {
   res.json({
     status: "ok",
     copilotCli: isCopilotCliAvailable(),
-    authenticated: isAuthenticated(),
   });
 });
 
 // List available models
-app.get("/api/models", async (_req: Request, res: Response) => {
+app.get("/api/models", async (req: Request, res: Response) => {
+  const token = extractToken(req);
+  if (!token) {
+    res.status(401).json({ error: "Missing token. Provide Authorization: Bearer <token> header." });
+    return;
+  }
   try {
-    const c = await getClient();
+    const c = await getClientForToken(token);
     const models = await c.listModels();
     res.json({ models });
   } catch (err: any) {
@@ -84,6 +88,12 @@ app.get("/api/models", async (_req: Request, res: Response) => {
 
 // Chat endpoint (SSE streaming)
 app.post("/api/chat", async (req: Request, res: Response) => {
+  const token = extractToken(req);
+  if (!token) {
+    res.status(401).json({ error: "Missing token. Provide Authorization: Bearer <token> header." });
+    return;
+  }
+
   const { message, sessionId, model } = req.body;
 
   if (!message || typeof message !== "string") {
@@ -98,13 +108,14 @@ app.post("/api/chat", async (req: Request, res: Response) => {
   res.flushHeaders();
 
   try {
-    const c = await getClient();
+    const c = await getClientForToken(token);
 
     let session: CopilotSession;
     let sid = sessionId;
+    const key = sid ? sessionKey(token, sid) : "";
 
-    if (sid && sessions.has(sid)) {
-      session = sessions.get(sid)!;
+    if (sid && sessions.has(key)) {
+      session = sessions.get(key)!;
     } else {
       sid = sid || generateSessionId();
       session = await c.createSession({
@@ -112,7 +123,7 @@ app.post("/api/chat", async (req: Request, res: Response) => {
         streaming: true,
         onPermissionRequest: approveAll,
       });
-      sessions.set(sid, session);
+      sessions.set(sessionKey(token, sid), session);
     }
 
     // Collect unsubscribe functions
@@ -170,13 +181,10 @@ const server = app.listen(PORT, () => {
 // Graceful shutdown
 async function shutdown() {
   console.log("\nShutting down...");
-  if (client) {
-    try {
-      await client.stop();
-    } catch {
-      // ignore errors during shutdown
-    }
-  }
+  const stopPromises = [...clients.values()].map((c) =>
+    c.stop().catch(() => {})
+  );
+  await Promise.all(stopPromises);
   server.close();
   process.exit(0);
 }

--- a/test.ts
+++ b/test.ts
@@ -9,7 +9,7 @@ const BASE = `http://localhost:${PORT}`;
 const FREE_MODEL = "gpt-4.1"; // 0x premium requests on paid plans
 
 function buildClientOptions() {
-  const token = process.env.GITHUB_TOKEN;
+  const token = process.env.COPILOT_GITHUB_TOKEN;
   if (token) return { githubToken: token };
   return { useLoggedInUser: true };
 }
@@ -152,6 +152,12 @@ async function testSdkMultiTurn(): Promise<void> {
 
 let serverProcess: ChildProcess | null = null;
 
+function testAuthHeaders(): Record<string, string> {
+  const token = process.env.COPILOT_GITHUB_TOKEN;
+  if (token) return { Authorization: `Bearer ${token}` };
+  return {};
+}
+
 async function waitForServer(maxMs = 15000): Promise<boolean> {
   const start = Date.now();
   while (Date.now() - start < maxMs) {
@@ -170,11 +176,10 @@ async function testServerHealth(): Promise<void> {
   const res = await fetch(`${BASE}/api/health`);
   const data = await res.json();
   if (data.status !== "ok") throw new Error(`Expected "ok", got "${data.status}"`);
-  if (!data.authenticated) throw new Error("Server reports not authenticated");
 }
 
 async function testServerModels(): Promise<void> {
-  const res = await fetch(`${BASE}/api/models`);
+  const res = await fetch(`${BASE}/api/models`, { headers: testAuthHeaders() });
   const data = await res.json();
   if (!data.models || !Array.isArray(data.models) || data.models.length === 0) {
     throw new Error("No models returned from /api/models");
@@ -185,7 +190,7 @@ async function testServerModels(): Promise<void> {
 async function testServerChat(): Promise<void> {
   const res = await fetch(`${BASE}/api/chat`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...testAuthHeaders() },
     body: JSON.stringify({
       message: "Reply with exactly: SERVER_TEST_OK",
       model: FREE_MODEL,
@@ -225,7 +230,7 @@ async function testServerChat(): Promise<void> {
 // ============================================================
 
 async function main() {
-  // Auth: uses GITHUB_TOKEN from .env if set, otherwise falls back to gh CLI auth
+  // Auth: uses COPILOT_GITHUB_TOKEN from .env if set, otherwise falls back to gh CLI auth
 
   console.log("═══════════════════════════════════════════════");
   console.log("  Copilot Chat — Integration Tests");


### PR DESCRIPTION
## Summary

Refactors the app so each user provides their own GitHub token via the web UI instead of the server having a single global token. This enables multi-user support — different users can use the app with their own Copilot subscription.

## Changes

### Server (`server.ts`)
- **Per-user clients**: `Map<string, CopilotClient>` — one `CopilotClient` per unique token
- **Per-user sessions**: Sessions keyed by `token:sessionId` for isolation
- **Token extraction**: `extractToken()` reads `Authorization: Bearer <token>` header, falls back to `COPILOT_GITHUB_TOKEN` env var
- `/api/models` and `/api/chat` return 401 if no token provided
- `/api/health` remains unauthenticated
- Graceful shutdown stops all clients

### Frontend (`public/index.html` + `public/app.js`)
- **Token input**: Password field in header with Save/Clear toggle
- **localStorage**: Token stored in browser as `copilot_github_token`
- **Auth headers**: All API calls include `Authorization: Bearer <token>`
- Models only load when a token is saved

### Environment
- Renamed `GITHUB_TOKEN` → `COPILOT_GITHUB_TOKEN` (matches repo secret)
- Env var is now an optional fallback for testing/CI, not required for normal use

### Tests (`test.ts`)
- Updated to use `COPILOT_GITHUB_TOKEN` env var
- Server API tests send `Authorization` header
- Removed `authenticated` assertion from health check (field removed)

### Docs (`README.md`)
- Updated architecture diagram showing per-user token flow
- New authentication section explaining web UI token input
- Updated API docs noting which endpoints require auth
- Updated troubleshooting for 401 errors